### PR TITLE
user will now be able to use www htttp or just name of url.com

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -18,7 +18,6 @@ export default class ApplicationViews extends Component {
       news: [],
       messages: [],
       friends: []
-
     }
   }
 

--- a/src/components/messages/MessagesList.js
+++ b/src/components/messages/MessagesList.js
@@ -4,6 +4,7 @@ export default class MessagesList extends Component {
   render() {
     return(
       <>
+      <h2>Messages</h2>
       </>
     )
   }

--- a/src/components/news/AddNewsForm.js
+++ b/src/components/news/AddNewsForm.js
@@ -19,9 +19,17 @@ export default class AddNewsForm extends Component {
 
   addNewArticle = evt => {
     evt.preventDefault()
+    let urlCorrected = ""
+    if (this.state.url.split(".")[0] === "www") {
+        urlCorrected = `http://${this.state.url}`
+    } else if (this.state.url.split("/")[0] === "http:" || this.state.url.split("/")[0] === "https:") {
+        urlCorrected = this.state.url
+    } else {
+        urlCorrected = `https://www.${this.state.url}`
+    }
         const article = {
             userId: this.state.userId,
-            url: `http://${this.state.url}`,
+            url: urlCorrected,
             title: this.state.title,
             synopsis: this.state.synopsis,
             timeStamp: new Date()


### PR DESCRIPTION
# Description

Fixed bug in which i was not allowed to enter a new url without the www. or http: in front of it ... now when adding an article you can enter the url as http www or straight up website.com


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Testing Instructions for Change Made

under events tab add a news article.  there when you enter a website you can do it with full URL more laid back www.url or lazy website.com url


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works`
