### PR TITLE
Jb messages can friend now

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -70,7 +70,12 @@ render() {
 
   <Route path="/messages" render={props => {
     if (this.isAuthenticated()) {
-    return <MessagesList {...props} messages={this.props.messages} users={this.props.users} addMessage={this.addMessage} putMessage={this.putMessage} />
+    return <MessagesList {...props}
+      messages={this.props.messages}
+      users={this.props.users}
+      addMessage={this.addMessage}
+      putMessage={this.putMessage}
+      addFriend={this.addFriend} />
     } else {
       return <Redirect to='/' />
     }}} />

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -66,7 +66,9 @@ render() {
             messages={this.props.messages}
             users={this.props.users}
             addMessage={this.addMessage}
-            putMessage={this.putMessage} />
+            putMessage={this.putMessage}
+            addFriend={this.addFriend}
+             />
           }}
         />
 

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -75,7 +75,8 @@ render() {
       users={this.props.users}
       addMessage={this.addMessage}
       putMessage={this.putMessage}
-      addFriend={this.addFriend} />
+      addFriend={this.addFriend}
+      friends={this.props.friends} />
     } else {
       return <Redirect to='/' />
     }}} />

--- a/src/components/Nutshell.js
+++ b/src/components/Nutshell.js
@@ -71,7 +71,7 @@ export default class Nutshell extends Component {
     .then(messages => {this.setState({messages: messages})})
     .then(() => DataManager.getAll("friends"))
     .then(friends => {
-      let currentUser = 1;
+      let currentUser = Number(sessionStorage.getItem("User"));
       let friendsArray = [];
       friends.forEach(connection => {
         if(currentUser === connection.userId) {

--- a/src/components/messages/MessageEditButton.js
+++ b/src/components/messages/MessageEditButton.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react'
 export default class MessageEditButton extends Component {
 
   render() {
-    let userId = 1;
+    let userId = Number(sessionStorage.getItem("User"));
     if (userId !== this.props.message.userId) {
       return null
     }

--- a/src/components/messages/Messages.css
+++ b/src/components/messages/Messages.css
@@ -46,8 +46,16 @@
   margin: 0px 10px;
 }
 
-.message-container .nonUser-message h5 {
+.message-container .nonUser-message .message-is-a-friend {
   color: #222;
+  font-size: 12px;
+  font-weight: bold;
+  margin: 0px 40px;
+  text-align: right;
+}
+
+.message-container .nonUser-message .message-not-a-friend {
+  color: red;
   font-size: 12px;
   font-weight: bold;
   margin: 0px 40px;
@@ -57,3 +65,4 @@
 .message-container .user-message a {
     text-decoration: underline;
 }
+

--- a/src/components/messages/Messages.css
+++ b/src/components/messages/Messages.css
@@ -4,7 +4,7 @@
   margin-bottom: 10px;
   overflow-y: auto;
     margin: 10px;
-    max-width: 400px;
+    max-width: 600px;
 
 }
 

--- a/src/components/messages/MessagesCard.js
+++ b/src/components/messages/MessagesCard.js
@@ -7,7 +7,15 @@ export default class MessagesCard extends Component {
   render() {
 
     let userId = 1;
-    console.log("messageIdForEditing",this.props.messageIdForEditing)
+    console.log("this is friends from user database",this.props.friends)
+
+     let isThisAFriend = this.props.friends.find(friends => friends.id === this.props.message.userId)
+    console.log(isThisAFriend)
+
+    let itIsNotAFriend = false
+    if (isThisAFriend === undefined) {
+      itIsNotAFriend = true
+    }
 
     let useris ="";
     let personIs = this.props.userDatabase.find(user => user.id === this.props.userId)
@@ -34,6 +42,7 @@ export default class MessagesCard extends Component {
       </section>
       )
     }
+    if (itIsNotAFriend) {
     return(
       <section className={`${useris}-message`}>
       <a onClick={()=> this.props.addFriend(addFriendObject)} ><h5>{personIs.userName}</h5></a>
@@ -42,6 +51,16 @@ export default class MessagesCard extends Component {
           history={this.props.history}
           messageToEdit={this.props.messageToEdit} /></p>
       </section>
-    )
+    )} else {
+      return(
+              <section className={`${useris}-message`}>
+      <h5>{personIs.userName}</h5>
+      <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
+      <MessageEditButton message={this.props.message}
+          history={this.props.history}
+          messageToEdit={this.props.messageToEdit} /></p>
+      </section>
+      )
+    }
   }
 }

--- a/src/components/messages/MessagesCard.js
+++ b/src/components/messages/MessagesCard.js
@@ -16,6 +16,12 @@ export default class MessagesCard extends Component {
     } else {
       useris = "nonUser"
     }
+
+    const addFriendObject = {
+      userId: userId,
+      otherFriendId: personIs.id,
+    }
+
     if (this.props.messageIdForEditing === this.props.message.id) {
       return(
       <section className={`${useris}-message`}>
@@ -30,7 +36,7 @@ export default class MessagesCard extends Component {
     }
     return(
       <section className={`${useris}-message`}>
-      <h5>{personIs.userName}</h5>
+      <a onClick={()=> this.props.addFriend(addFriendObject)} ><h5>{personIs.userName}</h5></a>
       <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
       <MessageEditButton message={this.props.message}
           history={this.props.history}

--- a/src/components/messages/MessagesCard.js
+++ b/src/components/messages/MessagesCard.js
@@ -45,7 +45,7 @@ export default class MessagesCard extends Component {
     if (itIsNotAFriend) {
     return(
       <section className={`${useris}-message`}>
-      <a onClick={()=> this.props.addFriend(addFriendObject)} ><h5>{personIs.userName}</h5></a>
+      <a onClick={()=> this.props.addFriend(addFriendObject)} ><h5 className="message-not-a-friend">{personIs.userName}</h5></a>
       <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
       <MessageEditButton message={this.props.message}
           history={this.props.history}
@@ -54,7 +54,7 @@ export default class MessagesCard extends Component {
     )} else {
       return(
               <section className={`${useris}-message`}>
-      <a onClick={() => alert("already a friend")}><h5>{personIs.userName}</h5></a>
+      <a onClick={() => alert("already a friend")}><h5 className="message-is-a-friend">{personIs.userName}</h5></a>
       <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
       <MessageEditButton message={this.props.message}
           history={this.props.history}

--- a/src/components/messages/MessagesCard.js
+++ b/src/components/messages/MessagesCard.js
@@ -54,7 +54,7 @@ export default class MessagesCard extends Component {
     )} else {
       return(
               <section className={`${useris}-message`}>
-      <h5>{personIs.userName}</h5>
+      <a onClick={() => alert("already a friend")}><h5>{personIs.userName}</h5></a>
       <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
       <MessageEditButton message={this.props.message}
           history={this.props.history}

--- a/src/components/messages/MessagesCard.js
+++ b/src/components/messages/MessagesCard.js
@@ -6,14 +6,16 @@ export default class MessagesCard extends Component {
 
   render() {
 
-    let userId = 1;
+    let userId = Number(sessionStorage.getItem("User"));
     console.log("this is friends from user database",this.props.friends)
 
-     let isThisAFriend = this.props.friends.find(friends => friends.id === this.props.message.userId)
+     let isThisAFriend = this.props.friends.find(friends => friends.id === this.props.message.userId) || null
     console.log(isThisAFriend)
 
+    let isSelf = (userId === this.props.message.userId) ? true : false;
+
     let itIsNotAFriend = false
-    if (isThisAFriend === undefined) {
+    if (isThisAFriend === null) {
       itIsNotAFriend = true
     }
 
@@ -42,25 +44,38 @@ export default class MessagesCard extends Component {
       </section>
       )
     }
-    if (itIsNotAFriend) {
-    return(
-      <section className={`${useris}-message`}>
-      <a onClick={()=> this.props.addFriend(addFriendObject)} ><h5 className="message-not-a-friend">{personIs.userName}</h5></a>
-      <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
-      <MessageEditButton message={this.props.message}
-          history={this.props.history}
-          messageToEdit={this.props.messageToEdit} /></p>
-      </section>
-    )} else {
+    if (isSelf) {
       return(
-              <section className={`${useris}-message`}>
-      <a onClick={() => alert("already a friend")}><h5 className="message-is-a-friend">{personIs.userName}</h5></a>
+      <section className={`${useris}-message`}>
+      <h5 className="message-not-a-friend">{personIs.userName}</h5>
       <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
       <MessageEditButton message={this.props.message}
           history={this.props.history}
           messageToEdit={this.props.messageToEdit} /></p>
       </section>
       )
-    }
+    } else  if (itIsNotAFriend) {
+      return(
+        <section className={`${useris}-message`}>
+        <a onClick={()=> this.props.addFriend(addFriendObject)} ><h5 className="message-not-a-friend">{personIs.userName}</h5></a>
+        <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
+        {/* <MessageEditButton message={this.props.message}
+            history={this.props.history}
+            messageToEdit={this.props.messageToEdit}  /> */}
+            </p>
+        </section>
+      )
+      } else {
+      return(
+              <section className={`${useris}-message`}>
+      <a onClick={() => alert("already a friend")}><h5 className="message-is-a-friend">{personIs.userName}</h5></a>
+      <p id={`message-${this.props.message.id}`}>{this.props.message.message} <br/>
+      {/* <MessageEditButton message={this.props.message}
+          history={this.props.history}
+          messageToEdit={this.props.messageToEdit} /> */}
+          </p>
+      </section>
+      )
+      }
   }
 }

--- a/src/components/messages/MessagesList.js
+++ b/src/components/messages/MessagesList.js
@@ -34,7 +34,8 @@ export default class MessagesList extends Component {
         userDatabase={this.props.users}
         messageToEdit={messageToEdit}
         messageIdForEditing={this.state.messageIdForEditing}
-        putMessage={this.props.putMessage} />
+        putMessage={this.props.putMessage}
+        addFriend={this.props.addFriend} />
       )
         }
         <MessagesAddMessage

--- a/src/components/messages/MessagesList.js
+++ b/src/components/messages/MessagesList.js
@@ -18,7 +18,7 @@ export default class MessagesList extends Component {
     }
 
 
-    if (this.props.messages.length === 0 ||  this.props.users.length === 0) {
+    if (this.props.messages.length === 0 ||  this.props.users.length === 0 || this.props.friends.length === 0) {
       return null
     }
     return(
@@ -35,7 +35,8 @@ export default class MessagesList extends Component {
         messageToEdit={messageToEdit}
         messageIdForEditing={this.state.messageIdForEditing}
         putMessage={this.props.putMessage}
-        addFriend={this.props.addFriend} />
+        addFriend={this.props.addFriend}
+        friends={this.props.friends} />
       )
         }
         <MessagesAddMessage

--- a/src/components/messages/MessagesList.js
+++ b/src/components/messages/MessagesList.js
@@ -9,7 +9,7 @@ export default class MessagesList extends Component {
     messageIdForEditing: 0,
   }
   render() {
-    let userId = 1
+    let userId = Number(sessionStorage.getItem("User"));
 
      const messageToEdit = (messageId) => {
       console.log(messageId, userId)
@@ -18,7 +18,7 @@ export default class MessagesList extends Component {
     }
 
 
-    if (this.props.messages.length === 0 ||  this.props.users.length === 0 || this.props.friends.length === 0) {
+    if (this.props.messages.length === 0 ||  this.props.users.length === 0) {
       return null
     }
     return(


### PR DESCRIPTION
# Description

Messages section will now allow you to click on fellow users names to add them as a friend.  Upon clicking... if they're already a friend browser will alert you that they're a friend and they will not become a friend.  
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Testing Instructions for Change Made

fetch and run jb-messagesCanFriendNow branch.  via the friends tab figure out who your friends are then in message tab add a non friend by clicking their name... then click their name again and you'll see they're now a friend are warned and un-allowed to friend them. Also notice that non-friends are red!


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works`
